### PR TITLE
feat: add onboarding wizard shell

### DIFF
--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -13,12 +13,16 @@ class VerifyEmailController extends Controller
      */
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        $user = $request->user();
+
+        if (! $user->hasVerifiedEmail()) {
+            $request->fulfill();
         }
 
-        $request->fulfill();
+        $user->initializeOnboardingState();
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        $destination = $user->hasCompletedOnboarding() ? 'dashboard' : 'onboarding.wizard';
+
+        return redirect()->intended(route($destination, absolute: false).'?verified=1');
     }
 }

--- a/app/Http/Middleware/EnsureOnboardingIsComplete.php
+++ b/app/Http/Middleware/EnsureOnboardingIsComplete.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureOnboardingIsComplete
+{
+    /**
+     * Redirect users who have not finished onboarding.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user !== null && ! $user->hasCompletedOnboarding()) {
+            return redirect()->route('onboarding.wizard');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/RedirectIfOnboardingComplete.php
+++ b/app/Http/Middleware/RedirectIfOnboardingComplete.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectIfOnboardingComplete
+{
+    /**
+     * Redirect users who have already finished onboarding away from the wizard.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user !== null && $user->hasCompletedOnboarding()) {
+            return redirect()->route('dashboard');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Support\Onboarding;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
@@ -22,6 +23,9 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'onboarding_step',
+        'onboarding_state',
+        'onboarded_at',
     ];
 
     /**
@@ -44,6 +48,8 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'onboarding_state' => 'array',
+            'onboarded_at' => 'datetime',
         ];
     }
 
@@ -57,5 +63,44 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    /**
+     * Determine if the user has finished onboarding.
+     */
+    public function hasCompletedOnboarding(): bool
+    {
+        return $this->onboarded_at !== null;
+    }
+
+    /**
+     * Initialize the onboarding state for a newly created user.
+     */
+    public function initializeOnboardingState(): void
+    {
+        if ($this->onboarding_state !== null) {
+            return;
+        }
+
+        $defaultStep = 1;
+
+        $this->forceFill([
+            'onboarding_step' => $defaultStep,
+            'onboarding_state' => [
+                'current_step' => $defaultStep,
+                'completed' => [],
+                'total' => Onboarding::totalSteps(),
+            ],
+        ])->save();
+    }
+
+    /**
+     * Boot the model and configure onboarding defaults.
+     */
+    protected static function booted(): void
+    {
+        static::created(function (self $user): void {
+            $user->initializeOnboardingState();
+        });
     }
 }

--- a/app/Support/Onboarding.php
+++ b/app/Support/Onboarding.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Support;
+
+class Onboarding
+{
+    /**
+     * Retrieve the ordered onboarding steps.
+     *
+     * @return array<int, array<string, string>>
+     */
+    public static function steps(): array
+    {
+        return [
+            [
+                'key' => 'compliance-region',
+                'title' => 'Compliance region',
+                'description' => 'Select where MediNotes should enforce jurisdictional rules.',
+            ],
+            [
+                'key' => 'phi-toggle',
+                'title' => 'Protected health information',
+                'description' => 'Declare whether the practice will store PHI and handle BAA obligations.',
+            ],
+            [
+                'key' => 'practice-setup',
+                'title' => 'Practice workspace',
+                'description' => 'Create or join the practice that will use MediNotes.',
+            ],
+            [
+                'key' => 'processing-defaults',
+                'title' => 'Processing defaults',
+                'description' => 'Choose engines, diarization, and redaction defaults for new encounters.',
+            ],
+            [
+                'key' => 'outputs',
+                'title' => 'Output formats',
+                'description' => 'Confirm which transcript artifacts should be generated automatically.',
+            ],
+            [
+                'key' => 'templates',
+                'title' => 'Specialty templates',
+                'description' => 'Select the clinical note templates that best match the practice.',
+            ],
+        ];
+    }
+
+    /**
+     * Get the total number of onboarding steps.
+     */
+    public static function totalSteps(): int
+    {
+        return count(self::steps());
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Middleware\EnsureOnboardingIsComplete;
+use App\Http\Middleware\RedirectIfOnboardingComplete;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'onboarding.complete' => EnsureOnboardingIsComplete::class,
+            'onboarding.incomplete' => RedirectIfOnboardingComplete::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Support\Onboarding;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -29,6 +30,13 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'onboarding_step' => 1,
+            'onboarding_state' => [
+                'current_step' => 1,
+                'completed' => [],
+                'total' => Onboarding::totalSteps(),
+            ],
+            'onboarded_at' => null,
         ];
     }
 
@@ -40,5 +48,25 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    /**
+     * Mark the user as fully onboarded.
+     */
+    public function withOnboardingCompleted(): static
+    {
+        return $this->state(function (array $attributes) {
+            $total = Onboarding::totalSteps();
+
+            return [
+                'onboarding_step' => $total,
+                'onboarding_state' => [
+                    'current_step' => $total,
+                    'completed' => range(1, $total),
+                    'total' => $total,
+                ],
+                'onboarded_at' => now(),
+            ];
+        });
     }
 }

--- a/database/migrations/2024_05_11_000001_add_onboarding_columns_to_users_table.php
+++ b/database/migrations/2024_05_11_000001_add_onboarding_columns_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedTinyInteger('onboarding_step')->default(1)->after('remember_token');
+            $table->json('onboarding_state')->nullable()->after('onboarding_step');
+            $table->timestamp('onboarded_at')->nullable()->after('onboarding_state');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'onboarding_step',
+                'onboarding_state',
+                'onboarded_at',
+            ]);
+        });
+    }
+};

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,228 @@
+# MediNotes Implementation Backlog
+
+The following numbered tickets break down the MediNotes build. Each item includes a semantic title, scope notes, suggested labels, story points (Fibonacci scale), and acceptance criteria.
+
+1. **feat: scaffold onboarding authentication & wizard shell**
+   * **Scope:** Install and configure Laravel Breeze with email verification, set up Livewire layout, and create the multi-step wizard container triggered post-registration.
+   * **Labels:** `feature`, `frontend`, `backend`, `onboarding`
+   * **Story Points:** 5
+   * **Acceptance Criteria:**
+     - Breeze auth views updated with MediNotes branding and email verification enforced.
+     - Completing sign-up routes verified users into a Livewire-driven wizard shell with step navigation and persistence.
+     - Wizard progress saved per user allowing resume after refresh.
+
+2. **feat: compliance region & PHI step logic**
+   * **Scope:** Implement wizard step for selecting compliance region (HIPAA, POPIA, GDPR) and toggling PHI usage with contextual guidance.
+   * **Labels:** `feature`, `frontend`, `compliance`
+   * **Story Points:** 3
+   * **Acceptance Criteria:**
+     - Compliance region options persisted on the user profile/team.
+     - PHI toggle reveals BAA requirement messaging and cannot continue without acknowledgement.
+     - Step validates selection before allowing progression.
+
+3. **feat: BAA document upload and validation**
+   * **Scope:** Allow teams to upload, store, and manage Business Associate Agreements; enforce validity dates when PHI toggle is enabled.
+   * **Labels:** `feature`, `backend`, `storage`, `compliance`
+   * **Story Points:** 5
+   * **Acceptance Criteria:**
+     - Teams can upload BAA PDFs to private storage with metadata (number, effective, expiry).
+     - PHI-enabled accounts blocked if no active BAA; wizard displays actionable error.
+     - Audit log records BAA upload and renewal actions.
+
+4. **feat: practice setup step (create or join)**
+   * **Scope:** Provide wizard step for creating a new practice or joining an existing one via invite/join code, including role assignment.
+   * **Labels:** `feature`, `frontend`, `backend`, `practice`
+   * **Story Points:** 5
+   * **Acceptance Criteria:**
+     - Users can create practices with name and address fields or join existing by invite token.
+     - Team membership stored with role (owner, admin, member) and reflected on dashboard.
+     - Step handles invalid invite tokens gracefully with inline feedback.
+
+5. **feat: default engine, diarization, and redaction preferences**
+   * **Scope:** Build wizard step for selecting transcription engine, diarization toggle, language auto-detect, and redaction default.
+   * **Labels:** `feature`, `frontend`, `settings`
+   * **Story Points:** 3
+   * **Acceptance Criteria:**
+     - Engine choices surfaced from config and persisted on user/practice defaults.
+     - Diarization and redaction toggles persist and feed into future jobs.
+     - Validation ensures at least one engine is selectable; unavailable engines hidden.
+
+6. **feat: output format & specialty template preferences**
+   * **Scope:** Combine wizard steps to capture preferred artifact formats (TXT, JSON, SRT, VTT, DOCX) and default specialty templates.
+   * **Labels:** `feature`, `frontend`, `templates`
+   * **Story Points:** 3
+   * **Acceptance Criteria:**
+     - Users can select multiple output formats with explanation of availability (DOCX optional).
+     - Specialty template checklist persisted per user.
+     - Wizard summary step confirms selections prior to dashboard redirect.
+
+7. **feat: doctor dashboard layout & navigation**
+   * **Scope:** Create dashboard view with welcome header, quick actions, recent encounters, analytics snapshot, and persistent sidebar navigation.
+   * **Labels:** `feature`, `frontend`, `ui`
+   * **Story Points:** 5
+   * **Acceptance Criteria:**
+     - Sidebar includes Dashboard, Encounters, Templates, Practice, Compliance, Settings.
+     - Quick action buttons trigger navigation to encounter creation, upload modal, and recorder.
+     - Recent encounters table and analytics placeholders render with sample data.
+
+8. **feat: encounter quick action modal triggers**
+   * **Scope:** Wire quick actions to modals/forms for recording voice, uploading audio, and uploading documents with consistent styling.
+   * **Labels:** `feature`, `frontend`, `encounters`
+   * **Story Points:** 5
+   * **Acceptance Criteria:**
+     - Record Voice modal includes start/pause/resume controls and waveform placeholder.
+     - Upload Audio accepts drag-drop and file picker with validation on file types.
+     - Upload Documents supports multiple file selection and indicates supported formats.
+
+9. **feat: resumable chunked uploads (tier 1)**
+   * **Scope:** Implement Livewire chunked uploads for files up to ~2 GB with progress tracking and retry on network loss.
+   * **Labels:** `feature`, `backend`, `storage`
+   * **Story Points:** 8
+   * **Acceptance Criteria:**
+     - Chunked upload progress bar updates in real time and resumes after transient failure.
+     - Successful upload moves file to S3 (or configured disk) before finalization.
+     - Upload manifest cleaned on completion or cancellation.
+
+10. **feat: S3 multipart upload support (tier 2)**
+    * **Scope:** Provide presigned multipart upload API for very large files with pause/resume and integrity validation of parts.
+    * **Labels:** `feature`, `backend`, `storage`, `performance`
+    * **Story Points:** 13
+    * **Acceptance Criteria:**
+      - Client receives upload id and part URLs, can pause/resume by reusing manifest.
+      - Server validates ETags and assembles multipart object; mismatched parts flagged for re-upload.
+      - Multipart uploads recoverable after browser refresh.
+
+11. **feat: finalize encounter creation & dedup hashing**
+    * **Scope:** Stream-hash uploaded files, enforce per-user dedup, and create transcription job entries with queued status.
+    * **Labels:** `feature`, `backend`, `encounters`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - SHA-256 computed via stream without loading entire file into memory.
+      - Duplicate uploads return existing job reference with notification to the user.
+      - Finalization responds within 2 seconds after upload completion.
+
+12. **feat: transcription job dispatch & queue workflow**
+    * **Scope:** Create queue job for transcription processing, ensuring uniqueness, retries, and integration with engine driver abstraction.
+    * **Labels:** `feature`, `backend`, `queue`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - Queue job transitions statuses (queued → processing → complete/failed) with progress updates.
+      - Retries reuse stable external job ids; exponential backoff configured.
+      - Failed jobs record error detail and emit events to timeline.
+
+13. **feat: encounter detail processing timeline**
+    * **Scope:** Build Encounter Detail page with header, file summary, status timeline, progress bar, and live event log.
+    * **Labels:** `feature`, `frontend`, `encounters`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Timeline shows stages (Queued, Processing, Diarizing/OCR, Outputs, Complete) with active state highlight.
+      - Event log streams updates via Livewire polling or broadcast.
+      - Download buttons remain disabled until artifacts exist.
+
+14. **feat: OCR ingestion for document uploads**
+    * **Scope:** Process uploaded document images/PDFs through OCR pipeline and merge text into encounter transcript package.
+    * **Labels:** `feature`, `backend`, `ocr`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - OCR results stored alongside audio transcript segments with source metadata.
+      - Errors isolated per document without failing entire encounter; surfaced in event log.
+      - OCR respects PHI redaction settings.
+
+15. **feat: medical AI summarization & coding**
+    * **Scope:** Integrate medical LLM layer to generate clinical summary and propose ICD-10/SNOMED codes from combined transcript data.
+    * **Labels:** `feature`, `backend`, `ai`, `billing`
+    * **Story Points:** 13
+    * **Acceptance Criteria:**
+      - Summary text stored and displayed on encounter completion view.
+      - Proposed codes include description, confidence, and editable fields.
+      - Redaction rules applied before storing AI outputs when PHI flag is enabled.
+
+16. **feat: encounter completion actions & downloads**
+    * **Scope:** Display clinical summary, code approval checkboxes, template dropdown/preview, and download buttons for TXT, JSON, SRT, VTT, DOCX (if enabled).
+    * **Labels:** `feature`, `frontend`, `encounters`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - Template preview auto-populates from transcript with editable fields.
+      - Download buttons generate signed URLs with audit entries per click.
+      - "Approve Codes & Send to Billing" triggers export workflow and status confirmation.
+
+17. **feat: templates management page**
+    * **Scope:** Provide templates index with preview, edit, set default, and add-new functionality, supporting template types (SOAP, Discharge, Referral, etc.).
+    * **Labels:** `feature`, `frontend`, `templates`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Templates list shows name, description, and type with action buttons.
+      - Editing uses form with Livewire validation; changes versioned/audited.
+      - Setting default updates user/practice preference used in encounters.
+
+18. **feat: practice management workspace**
+    * **Scope:** Build practice page showing profile details, linked doctors, admins, billing integration status, and BAA validity.
+    * **Labels:** `feature`, `frontend`, `practice`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Practice profile fields editable by owners/admins and read-only for members.
+      - Linked users displayed with roles and invitation management.
+      - Billing integrations status indicators reflect configured connectors.
+
+19. **feat: compliance console**
+    * **Scope:** Create compliance page summarizing region, PHI toggle, BAA upload/renew, data residency, and audit log export actions.
+    * **Labels:** `feature`, `frontend`, `compliance`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Page displays current compliance settings and allows toggling within policy constraints.
+      - BAA renewal workflow accessible outside wizard with expiration warnings.
+      - Audit log export triggers background job and delivers downloadable report.
+
+20. **feat: user settings center**
+    * **Scope:** Implement settings page for profile details, engine defaults, output format preferences, and notification toggles.
+    * **Labels:** `feature`, `frontend`, `settings`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Profile form updates name, specialty, and contact info with validation.
+      - Engine and output preferences sync with encounter defaults.
+      - Notification toggles persist and inform email/in-app alerts configuration.
+
+21. **feat: analytics dashboard (doctor view)**
+    * **Scope:** Deliver analytics view with charts for top ICD-10 codes, consultation types, average turnaround, and billing status split.
+    * **Labels:** `feature`, `frontend`, `analytics`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - Charts render with Livewire-friendly visualization library using aggregated encounter data.
+      - Analytics respect date filters and doctor/team scope.
+      - Loading states and empty states handled gracefully.
+
+22. **feat: billing export integration**
+    * **Scope:** Implement export of approved codes to practice billing systems (Healthbridge, MedEDI, Vericlaim) and notify assigned billing agents.
+    * **Labels:** `feature`, `backend`, `billing`, `integration`
+    * **Story Points:** 13
+    * **Acceptance Criteria:**
+      - Billing connectors configurable per practice with credential validation.
+      - Approved codes generate structured payloads and transmit via API/SFTP as configured.
+      - Success/failure logged with retries on transient transport errors.
+
+23. **chore: audit logging & compliance enforcement**
+    * **Scope:** Capture audit events for uploads, downloads, retries, deletions, BAA actions, and ensure PHI redaction controls apply system-wide.
+    * **Labels:** `chore`, `backend`, `compliance`, `security`
+    * **Story Points:** 8
+    * **Acceptance Criteria:**
+      - Audit table populated for each sensitive action with actor, timestamp, and metadata.
+      - PHI-flagged jobs mask sensitive text in logs and event streams.
+      - Compliance reports exportable per time range for regulators.
+
+24. **chore: observability & admin queue monitoring**
+    * **Scope:** Provide admin-only dashboard summarizing queue health, job throughput, failures, and link to Horizon (if Redis) or custom metrics.
+    * **Labels:** `chore`, `backend`, `observability`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Admin dashboard displays queue depth, average processing time, and failure counts.
+      - Admins can requeue or cancel stuck jobs with confirmation prompts.
+      - Access restricted to admin role with audit entries for actions.
+
+25. **chore: automated testing & CI scaffolding**
+    * **Scope:** Establish Pest/PHPUnit suites covering core flows, configure GitHub Actions (or alternative) for linting, tests, and asset build, and document runbook.
+    * **Labels:** `chore`, `testing`, `ci-cd`
+    * **Story Points:** 5
+    * **Acceptance Criteria:**
+      - Unit and feature tests cover upload finalization, dedup, permissions, artifact downloads, and billing export stubs.
+      - CI pipeline runs linting and tests on pull requests with status badges.
+      - README updated with testing commands and CI overview.

--- a/resources/views/components/layouts/onboarding.blade.php
+++ b/resources/views/components/layouts/onboarding.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+    <head>
+        @include('partials.head')
+    </head>
+    <body class="min-h-screen bg-slate-50 font-sans antialiased text-slate-900 dark:bg-neutral-950 dark:text-slate-100">
+        <div class="flex min-h-svh flex-col">
+            <header class="border-b border-slate-200/80 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-neutral-950/80">
+                <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-6 py-5">
+                    <a href="{{ route('home') }}" class="flex items-center gap-3" wire:navigate>
+                        <span class="flex size-9 items-center justify-center rounded-md bg-slate-900 text-white dark:bg-white dark:text-slate-900">
+                            <x-app-logo-icon class="size-5" />
+                        </span>
+                        <span class="text-base font-semibold tracking-tight">{{ config('app.name', 'MediNotes') }}</span>
+                    </a>
+
+                    <span class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Guided onboarding</span>
+                </div>
+            </header>
+
+            <main class="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-12">
+                {{ $slot }}
+            </main>
+        </div>
+
+        @fluxScripts
+    </body>
+</html>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -31,6 +31,8 @@ new #[Layout('components.layouts.auth')] class extends Component {
 
         Auth::login($user);
 
+        $user->initializeOnboardingState();
+
         $this->redirectIntended(route('dashboard', absolute: false), navigate: true);
     }
 }; ?>

--- a/resources/views/livewire/onboarding/wizard.blade.php
+++ b/resources/views/livewire/onboarding/wizard.blade.php
@@ -1,0 +1,242 @@
+<?php
+
+use App\Support\Onboarding;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Title;
+use Livewire\Volt\Component;
+
+new #[Layout('components.layouts.onboarding'), Title('Complete MediNotes onboarding')] class extends Component {
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $steps = [];
+
+    public int $currentStep = 1;
+
+    /**
+     * @var array<int>
+     */
+    public array $completedSteps = [];
+
+    public bool $emailJustVerified = false;
+
+    public function mount(): void
+    {
+        $this->steps = Onboarding::steps();
+        $this->emailJustVerified = request()->boolean('verified');
+
+        $user = auth()->user();
+        $user->initializeOnboardingState();
+        $user->refresh();
+
+        $state = $user->onboarding_state ?? [];
+
+        $this->currentStep = (int) ($state['current_step'] ?? $user->onboarding_step ?? 1);
+        $this->completedSteps = array_values(array_unique(array_map('intval', $state['completed'] ?? [])));
+        sort($this->completedSteps);
+
+        $this->persistProgress();
+    }
+
+    public function goToStep(int $step): void
+    {
+        if (! $this->isValidStep($step)) {
+            return;
+        }
+
+        $this->currentStep = $step;
+        $this->persistProgress();
+    }
+
+    public function nextStep(): void
+    {
+        if ($this->currentStep >= count($this->steps)) {
+            return;
+        }
+
+        $this->markStepCompleted($this->currentStep);
+        $this->currentStep++;
+        $this->persistProgress();
+    }
+
+    public function previousStep(): void
+    {
+        if ($this->currentStep <= 1) {
+            return;
+        }
+
+        $this->currentStep--;
+        $this->persistProgress();
+    }
+
+    public function complete(): void
+    {
+        $totalSteps = count($this->steps);
+
+        $this->markStepCompleted($this->currentStep);
+        $this->currentStep = $totalSteps;
+        $this->completedSteps = range(1, $totalSteps);
+
+        $user = auth()->user();
+        $user->forceFill([
+            'onboarding_step' => $this->currentStep,
+            'onboarding_state' => [
+                'current_step' => $this->currentStep,
+                'completed' => $this->completedSteps,
+                'total' => Onboarding::totalSteps(),
+            ],
+            'onboarded_at' => now(),
+        ])->save();
+
+        $this->redirect(route('dashboard', absolute: false), navigate: true);
+    }
+
+    protected function markStepCompleted(int $step): void
+    {
+        if (! in_array($step, $this->completedSteps, true)) {
+            $this->completedSteps[] = $step;
+            sort($this->completedSteps);
+        }
+    }
+
+    protected function persistProgress(): void
+    {
+        $user = auth()->user();
+
+        $user->forceFill([
+            'onboarding_step' => $this->currentStep,
+            'onboarding_state' => [
+                'current_step' => $this->currentStep,
+                'completed' => $this->completedSteps,
+                'total' => Onboarding::totalSteps(),
+            ],
+        ])->save();
+    }
+
+    protected function isValidStep(int $step): bool
+    {
+        return $step >= 1 && $step <= count($this->steps);
+    }
+}; ?>
+
+@php
+    $totalSteps = count($steps);
+    $activeStep = $steps[$currentStep - 1] ?? null;
+    $progress = $totalSteps > 0 ? intval(($currentStep / $totalSteps) * 100) : 0;
+
+    $placeholderCopy = static fn (array $step): string => match ($step['key']) {
+        'compliance-region' => 'Capture the regulatory region so MediNotes can apply HIPAA, POPIA, or GDPR storage rules. The upcoming step will surface these options with contextual guidance.',
+        'phi-toggle' => 'Decide whether this account will handle PHI. When implemented, enabling PHI will prompt for a Business Associate Agreement upload before the doctor can continue.',
+        'practice-setup' => 'Set up the practice space by creating a new organisation or joining an existing invite. Role assignments and invite handling will be wired in the following tickets.',
+        'processing-defaults' => 'Choose the default transcription engine, diarisation, redaction, and language handling options. Future tasks will persist these defaults to every new encounter.',
+        'outputs' => 'Pick the transcript formats that should be generated automatically (TXT, JSON, SRT, VTT, DOCX). Later work will store these preferences for downstream processing.',
+        'templates' => 'Select specialty templates such as SOAP, Discharge, or Referral notes. Template management and preview will land in subsequent tickets.',
+        default => 'Configure the remaining onboarding preferences.',
+    };
+@endphp
+
+<div class="space-y-10">
+    <header class="space-y-4">
+        <div>
+            <p class="text-sm font-semibold uppercase tracking-wide text-slate-500">Onboarding</p>
+            <h1 class="text-3xl font-semibold text-slate-900 dark:text-white">Complete your MediNotes setup</h1>
+            <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                Step {{ $currentStep }} of {{ $totalSteps }} · Progress {{ $progress }}%
+            </p>
+        </div>
+
+        <div class="h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+            <div class="h-full bg-sky-500 transition-all duration-300" style="width: {{ $progress }}%;"></div>
+        </div>
+
+        @if ($emailJustVerified)
+            <flux:alert variant="success">
+                {{ __('Thanks for verifying your email address. Let’s finish configuring MediNotes before you jump into encounters.') }}
+            </flux:alert>
+        @endif
+    </header>
+
+    <div class="grid gap-10 lg:grid-cols-[280px_1fr]">
+        <aside class="space-y-4">
+            <ol class="space-y-2">
+                @foreach ($steps as $index => $step)
+                    @php
+                        $stepNumber = $index + 1;
+                        $isActive = $currentStep === $stepNumber;
+                        $isComplete = in_array($stepNumber, $completedSteps, true);
+                    @endphp
+                    <li>
+                        <button
+                            type="button"
+                            wire:click="goToStep({{ $stepNumber }})"
+                            class="flex w-full items-center justify-between gap-3 rounded-lg border px-4 py-3 text-left transition hover:border-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 @if($isActive) border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950 dark:text-sky-100 @elseif($isComplete) border-emerald-400 bg-emerald-50 text-emerald-900 dark:border-emerald-400 dark:bg-emerald-950 dark:text-emerald-100 @else border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-200 @endif"
+                            @if($isActive) aria-current="step" @endif
+                        >
+                            <span class="flex items-center gap-3">
+                                <span class="flex size-7 items-center justify-center rounded-full text-sm font-semibold @if($isComplete) bg-emerald-500 text-white @elseif($isActive) bg-sky-500 text-white @else bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200 @endif">
+                                    {{ $stepNumber }}
+                                </span>
+                                <span class="flex flex-col">
+                                    <span class="text-sm font-medium">{{ $step['title'] }}</span>
+                                    <span class="text-xs text-slate-500 dark:text-slate-400">{{ $step['description'] }}</span>
+                                </span>
+                            </span>
+                            @if ($isComplete && ! $isActive)
+                                <span class="text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:text-emerald-400">Done</span>
+                            @endif
+                        </button>
+                    </li>
+                @endforeach
+            </ol>
+        </aside>
+
+        <section class="space-y-6">
+            @if ($activeStep)
+                <div class="space-y-4 rounded-2xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+                    <header class="space-y-2">
+                        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ __('Current step') }}</p>
+                        <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">{{ $activeStep['title'] }}</h2>
+                        <p class="text-sm text-slate-600 dark:text-slate-300">{{ $activeStep['description'] }}</p>
+                    </header>
+
+                    <div class="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-600 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-200">
+                        {{ $placeholderCopy($activeStep) }}
+                        <br><br>
+                        {{ __('This shell keeps your place. Upcoming tickets will replace it with the real form controls and data binding for each configuration step.') }}
+                    </div>
+                </div>
+            @endif
+
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <flux:button
+                    type="button"
+                    variant="ghost"
+                    wire:click="previousStep"
+                    :disabled="$currentStep === 1"
+                >
+                    {{ __('Back') }}
+                </flux:button>
+
+                <div class="flex items-center gap-3">
+                    @if ($currentStep < $totalSteps)
+                        <flux:button
+                            type="button"
+                            variant="outline"
+                            wire:click="nextStep"
+                        >
+                            {{ __('Save & continue') }}
+                        </flux:button>
+                    @else
+                        <flux:button
+                            type="button"
+                            variant="primary"
+                            wire:click="complete"
+                        >
+                            {{ __('Finish setup') }}
+                        </flux:button>
+                    @endif
+                </div>
+            </div>
+        </section>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,10 +8,14 @@ Route::get('/', function () {
 })->name('home');
 
 Route::view('dashboard', 'dashboard')
-    ->middleware(['auth', 'verified'])
+    ->middleware(['auth', 'verified', 'onboarding.complete'])
     ->name('dashboard');
 
-Route::middleware(['auth'])->group(function () {
+Volt::route('onboarding', 'onboarding.wizard')
+    ->middleware(['auth', 'verified', 'onboarding.incomplete'])
+    ->name('onboarding.wizard');
+
+Route::middleware(['auth', 'verified', 'onboarding.complete'])->group(function () {
     Route::redirect('settings', 'settings/profile');
 
     Volt::route('settings/profile', 'settings.profile')->name('settings.profile');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -12,7 +12,7 @@ test('login screen can be rendered', function () {
 });
 
 test('users can authenticate using the login screen', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $response = LivewireVolt::test('auth.login')
         ->set('email', $user->email)
@@ -27,7 +27,7 @@ test('users can authenticate using the login screen', function () {
 });
 
 test('users can not authenticate with invalid password', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $response = LivewireVolt::test('auth.login')
         ->set('email', $user->email)
@@ -40,7 +40,7 @@ test('users can not authenticate with invalid password', function () {
 });
 
 test('users can logout', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $response = $this->actingAs($user)->post('/logout');
 

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -30,8 +30,13 @@ test('email can be verified', function () {
 
     Event::assertDispatched(Verified::class);
 
-    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
-    $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
+    $user->refresh();
+
+    expect($user->hasVerifiedEmail())->toBeTrue();
+    expect($user->onboarding_step)->toBe(1);
+    expect($user->onboarded_at)->toBeNull();
+
+    $response->assertRedirect(route('onboarding.wizard', absolute: false).'?verified=1');
 });
 
 test('email is not verified with invalid hash', function () {

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -6,7 +6,7 @@ use Livewire\Volt\Volt;
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 test('confirm password screen can be rendered', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $response = $this->actingAs($user)->get('/confirm-password');
 
@@ -14,7 +14,7 @@ test('confirm password screen can be rendered', function () {
 });
 
 test('password can be confirmed', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 
@@ -28,7 +28,7 @@ test('password can be confirmed', function () {
 });
 
 test('password is not confirmed with invalid password', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -16,7 +16,7 @@ test('reset password link screen can be rendered', function () {
 test('reset password link can be requested', function () {
     Notification::fake();
 
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     Volt::test('auth.forgot-password')
         ->set('email', $user->email)
@@ -28,7 +28,7 @@ test('reset password link can be requested', function () {
 test('reset password screen can be rendered', function () {
     Notification::fake();
 
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     Volt::test('auth.forgot-password')
         ->set('email', $user->email)
@@ -46,7 +46,7 @@ test('reset password screen can be rendered', function () {
 test('password can be reset with valid token', function () {
     Notification::fake();
 
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     Volt::test('auth.forgot-password')
         ->set('email', $user->email)

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Livewire\Volt\Volt;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -23,4 +24,12 @@ test('new users can register', function () {
         ->assertRedirect(route('dashboard', absolute: false));
 
     $this->assertAuthenticated();
+
+    $user = User::first();
+
+    expect($user)->not->toBeNull();
+    expect($user->onboarding_step)->toBe(1);
+    expect($user->onboarding_state['current_step'] ?? null)->toBe(1);
+    expect($user->onboarding_state['completed'] ?? [])->toBe([]);
+    expect($user->onboarded_at)->toBeNull();
 });

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -9,8 +9,20 @@ test('guests are redirected to the login page', function () {
     $response->assertRedirect('/login');
 });
 
-test('authenticated users can visit the dashboard', function () {
-    $user = User::factory()->create();
+test('authenticated users who have not finished onboarding are redirected to the wizard', function () {
+    $user = User::factory()->create([
+        'onboarded_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    $response = $this->get('/dashboard');
+
+    $response->assertRedirect(route('onboarding.wizard'));
+});
+
+test('onboarded users can visit the dashboard', function () {
+    $user = User::factory()->withOnboardingCompleted()->create();
     $this->actingAs($user);
 
     $response = $this->get('/dashboard');

--- a/tests/Feature/Onboarding/OnboardingWizardTest.php
+++ b/tests/Feature/Onboarding/OnboardingWizardTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\User;
+use App\Support\Onboarding;
+use Livewire\Volt\Volt as LivewireVolt;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+test('unverified users are redirected to the verification notice before onboarding', function () {
+    $user = User::factory()->unverified()->create();
+
+    $this->actingAs($user);
+
+    $response = $this->get(route('onboarding.wizard'));
+
+    $response->assertRedirect(route('verification.notice'));
+});
+
+test('verified users who are not onboarded can view the wizard', function () {
+    $user = User::factory()->create([
+        'email_verified_at' => now(),
+        'onboarded_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    $response = $this->get(route('onboarding.wizard'));
+
+    $response->assertOk();
+});
+
+test('wizard progress persists to the user record', function () {
+    $user = User::factory()->create([
+        'email_verified_at' => now(),
+        'onboarded_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    LivewireVolt::test('onboarding.wizard')
+        ->call('nextStep');
+
+    $user->refresh();
+
+    expect($user->onboarding_step)->toBe(2);
+    expect($user->onboarding_state['current_step'] ?? null)->toBe(2);
+    expect($user->onboarding_state['completed'] ?? [])->toContain(1);
+    expect($user->onboarded_at)->toBeNull();
+});
+
+test('completing the wizard marks the user as onboarded', function () {
+    $user = User::factory()->create([
+        'email_verified_at' => now(),
+        'onboarded_at' => null,
+    ]);
+
+    $this->actingAs($user);
+
+    $component = LivewireVolt::test('onboarding.wizard');
+
+    $totalSteps = Onboarding::totalSteps();
+
+    $component
+        ->call('goToStep', $totalSteps)
+        ->call('complete')
+        ->assertRedirect(route('dashboard', absolute: false));
+
+    $user->refresh();
+
+    expect($user->hasCompletedOnboarding())->toBeTrue();
+    expect($user->onboarding_step)->toBe($totalSteps);
+    expect($user->onboarding_state['completed'] ?? [])->toEqual(range(1, $totalSteps));
+});

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -7,7 +7,7 @@ use Livewire\Volt\Volt;
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 test('password can be updated', function () {
-    $user = User::factory()->create([
+    $user = User::factory()->withOnboardingCompleted()->create([
         'password' => Hash::make('password'),
     ]);
 
@@ -25,7 +25,7 @@ test('password can be updated', function () {
 });
 
 test('correct password must be provided to update password', function () {
-    $user = User::factory()->create([
+    $user = User::factory()->withOnboardingCompleted()->create([
         'password' => Hash::make('password'),
     ]);
 

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -6,13 +6,13 @@ use Livewire\Volt\Volt;
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 test('profile page is displayed', function () {
-    $this->actingAs($user = User::factory()->create());
+    $this->actingAs($user = User::factory()->withOnboardingCompleted()->create());
 
     $this->get('/settings/profile')->assertOk();
 });
 
 test('profile information can be updated', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 
@@ -31,7 +31,7 @@ test('profile information can be updated', function () {
 });
 
 test('email verification status is unchanged when email address is unchanged', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 
@@ -46,7 +46,7 @@ test('email verification status is unchanged when email address is unchanged', f
 });
 
 test('user can delete their account', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 
@@ -63,7 +63,7 @@ test('user can delete their account', function () {
 });
 
 test('correct password must be provided to delete account', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->withOnboardingCompleted()->create();
 
     $this->actingAs($user);
 


### PR DESCRIPTION
## Summary
- track onboarding progress on users with a support helper, migration, and route middleware to gate dashboard access
- scaffold the MediNotes onboarding wizard shell with a dedicated layout and step placeholders to be filled in future tickets
- refresh verification flow, factory defaults, and feature coverage to reflect the onboarding requirements

## Testing
- php artisan test *(fails: composer install requires network/github auth so vendor autoload is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9910b89248333b57191dd5cbdb5e3